### PR TITLE
Fix version typo

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "description": "Hide Universal Access icon from the status bar",
   "url": "https://github.com/akiirui/hide-universal-access",
   "version": 8,
-  "shell-version": ["3.34", "3.36", "3.38", "40.0"]
+  "shell-version": ["3.34", "3.36", "3.38", "40"]
 }


### PR DESCRIPTION
Seems that gnome 40 ask for "40" string rather than "40.0" so here's a try to fix that